### PR TITLE
Add new 2023 Personal Identity Code reform characters

### DIFF
--- a/src/main/java/com/github/mpolla/HetuUtil.kt
+++ b/src/main/java/com/github/mpolla/HetuUtil.kt
@@ -55,10 +55,10 @@ public object HetuUtil : FinIdUtil() {
             return false
         }
         val separator : Char = id[6]
-        val yyyy = yy + when (separator) {
-            '+' -> 1800
-            '-' -> 1900
-            'A' -> 2000
+        val yyyy = yy + when {
+            arrayOf("+").contains(separator) -> 1800
+            arrayOf("-", "Y", "X", "W", "V", "U").contains(separator) -> 1900
+            arrayOf("A", "B", "C", "D", "E", "F").contains(separator) -> 2000
             else -> return false
         }
         // Third phase: does the day exist in the calendar?


### PR DESCRIPTION
In 2023 the new Finnish Personal Identity Code reform introduced new intermediate characters to PICs involving 1900s and 2000s.

This fix allows these new charactes to be identified as valid.

This fix does NOT affect the method 'getSeparatorChar' which tries to calculate the correct intermediate character based on the date. It still assumes only the original characters are in use for 1900s and 2000s.